### PR TITLE
Add automatic database migration for Vercel deployments

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+.env.local
+*.log
+.DS_Store

--- a/MIGRATION_INFO.md
+++ b/MIGRATION_INFO.md
@@ -1,0 +1,86 @@
+# Automatic Database Migration
+
+This project is configured to automatically run database migrations during deployment to Vercel.
+
+## How It Works
+
+When you deploy to Vercel:
+
+1. **Install Phase**: `npm install` runs, which also installs API dependencies
+2. **Build Phase**: `npm run build` executes, which:
+   - Runs `npm run migrate` (executes `scripts/auto-migrate.js`)
+   - Automatically creates/updates all database tables in Neon
+   - Then builds the React app
+
+## Migration Script
+
+The migration is handled by `scripts/auto-migrate.js`:
+
+- ✅ Reads the schema from `db/schema/001_initial_schema.sql`
+- ✅ Executes all SQL statements in order
+- ✅ Skips tables/objects that already exist (idempotent)
+- ✅ Uses the `POSTGRES_URL` environment variable
+- ✅ Provides detailed logging during deployment
+
+## Environment Variables Required
+
+Make sure these are set in Vercel:
+
+- `POSTGRES_URL` - Your Neon database connection string
+- `POSTGRES_PRISMA_URL` - Prisma connection string
+- `POSTGRES_URL_NON_POOLING` - Non-pooling connection
+
+## Manual Migration (if needed)
+
+If you need to run migrations manually:
+
+```bash
+# Install dependencies first
+npm install
+
+# Run migration
+npm run migrate
+```
+
+Or directly:
+
+```bash
+node scripts/auto-migrate.js
+```
+
+## Troubleshooting
+
+### Migration fails during deployment
+
+Check Vercel build logs for error messages. Common issues:
+
+1. **Missing POSTGRES_URL**: Make sure environment variable is set
+2. **Connection timeout**: Verify Neon database is active
+3. **Permission errors**: Check database user has CREATE permissions
+
+### Re-run migration
+
+Migrations are safe to run multiple times. They will skip existing tables.
+
+To force a fresh migration:
+1. Drop all tables in Neon Console
+2. Redeploy or run `npm run migrate`
+
+## Database Schema
+
+The schema creates these tables:
+
+- `users` - User accounts
+- `email_accounts` - Connected email providers
+- `emails` - Synced email messages
+- `email_drafts` - AI-generated drafts
+- `email_rules` - Custom email rules
+- `budget_usage` - API usage tracking
+- `api_usage_logs` - Detailed API logs
+- `notifications` - User notifications
+- `email_summaries` - Category summaries
+- `sessions` - JWT session management
+
+---
+
+**Migration runs automatically on every Vercel deployment!** ✅

--- a/package.json
+++ b/package.json
@@ -5,13 +5,18 @@
   "type": "module",
   "scripts": {
     "dev": "npm run dev --prefix app",
-    "build": "npm run build --prefix app",
+    "build": "npm run migrate && npm run build --prefix app",
     "preview": "npm run preview --prefix app",
     "install:app": "npm install --prefix app",
-    "install:api": "npm install --prefix api"
+    "install:api": "npm install --prefix api",
+    "migrate": "node scripts/auto-migrate.js",
+    "postinstall": "npm install --prefix api"
   },
   "workspaces": [
     "app",
     "api"
-  ]
+  ],
+  "dependencies": {
+    "@neondatabase/serverless": "^0.9.5"
+  }
 }

--- a/scripts/auto-migrate.js
+++ b/scripts/auto-migrate.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+ * Auto-migration script for Vercel deployments
+ * Runs database migrations automatically during build
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function runMigrations() {
+  console.log('🔄 Starting automatic database migration...');
+
+  // Check for database connection
+  const dbUrl = process.env.POSTGRES_URL || process.env.DATABASE_URL;
+
+  if (!dbUrl) {
+    console.error('❌ ERROR: No database connection string found!');
+    console.error('   Set POSTGRES_URL or DATABASE_URL environment variable');
+    process.exit(1);
+  }
+
+  try {
+    // Dynamic import to handle ESM
+    const { neon } = await import('@neondatabase/serverless');
+    const sql = neon(dbUrl);
+
+    console.log('📊 Reading schema file...');
+    const schemaPath = join(__dirname, '../db/schema/001_initial_schema.sql');
+    const schema = readFileSync(schemaPath, 'utf8');
+
+    console.log('🗄️  Executing database schema...');
+
+    // Split by semicolons and execute each statement
+    const statements = schema
+      .split(';')
+      .map(s => s.trim())
+      .filter(s => s.length > 0 && !s.startsWith('--'));
+
+    for (let i = 0; i < statements.length; i++) {
+      const statement = statements[i];
+      try {
+        await sql(statement);
+        if ((i + 1) % 5 === 0) {
+          console.log(`   Progress: ${i + 1}/${statements.length} statements`);
+        }
+      } catch (error) {
+        // Ignore "already exists" errors
+        if (error.message.includes('already exists')) {
+          console.log(`   ⚠️  Skipping existing object (${i + 1}/${statements.length})`);
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    console.log('✅ Database migrations completed successfully!');
+    console.log(`   Total statements executed: ${statements.length}`);
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error.message);
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+// Run if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runMigrations()
+    .then(() => process.exit(0))
+    .catch(error => {
+      console.error(error);
+      process.exit(1);
+    });
+}
+
+export default runMigrations;

--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+echo "🔄 Running database migrations..."
+
+# Check if we have the required environment variable
+if [ -z "$POSTGRES_URL" ]; then
+    echo "❌ ERROR: POSTGRES_URL not set"
+    exit 1
+fi
+
+# Set DATABASE_URL from POSTGRES_URL for the migration script
+export DATABASE_URL="$POSTGRES_URL"
+
+# Run the migration
+node db/migrations/migrate.js
+
+echo "✅ Database migrations completed successfully!"

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "version": 2,
+  "buildCommand": "npm run build",
+  "installCommand": "npm install",
   "builds": [
     {
       "src": "app/package.json",


### PR DESCRIPTION
This commit adds automatic database schema initialization that runs during every Vercel deployment, eliminating the need for manual setup.

Changes:
- Created scripts/auto-migrate.js: Automatic migration script with idempotent execution
- Created scripts/migrate-db.sh: Shell script for manual migration if needed
- Updated package.json: Added migrate script that runs before build
- Updated vercel.json: Added buildCommand and installCommand
- Created .vercelignore: Ignore unnecessary files during deployment
- Created MIGRATION_INFO.md: Documentation for migration process

How it works:
1. During Vercel build, npm install runs (installs dependencies)
2. npm run build executes, which first runs npm run migrate
3. Auto-migrate script reads db/schema/001_initial_schema.sql
4. Creates all tables, triggers, and indexes in Neon PostgreSQL
5. Skips existing objects (safe to run multiple times)
6. Then builds the React app

Database tables created:
- users, email_accounts, emails, email_drafts
- email_rules, budget_usage, api_usage_logs
- notifications, email_summaries, sessions

The migration is fully automatic and requires no manual intervention. Just deploy to Vercel and the database schema is ready!