### PR TITLE
Fix Vercel output directory configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "buildCommand": "npm run build",
+  "outputDirectory": "app/dist",
   "installCommand": "npm install",
   "rewrites": [
     {
@@ -13,7 +14,7 @@
     },
     {
       "source": "/((?!api).*)",
-      "destination": "/app/dist/index.html"
+      "destination": "/index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
- Added outputDirectory: app/dist to vercel.json
- Fixed rewrite rule for SPA routing
- This should resolve 'No Output Directory named dist found' error