### PR TITLE
Fix Vercel build - install app dependencies in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "install:app": "npm install --prefix app",
     "install:api": "npm install --prefix api",
     "migrate": "node scripts/auto-migrate.js",
-    "postinstall": "npm install --prefix api"
+    "postinstall": "npm install --prefix api && npm install --prefix app"
   },
   "workspaces": [
     "app",


### PR DESCRIPTION
- Updated postinstall to install both api and app dependencies
- Ensures Vite is available during build process
- Fixes 'vite: command not found' error